### PR TITLE
Service init script

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -67,6 +67,9 @@ Vagrant.configure(2) do |config|
     # Install Python dependencies.
     pip3 install -r /vagrant/app/requirements.txt
     pip3 install yapf
+    # Add a script for initializing the flask service.
+    echo 'cd /vagrant && sudo FLASK_APP=service:app flask run --host=0.0.0.0     --port=5000' > init_service.sh
+    chmod a+x init_service.sh
   SHELL
 
   ######################################################################

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -68,7 +68,7 @@ Vagrant.configure(2) do |config|
     pip3 install -r /vagrant/app/requirements.txt
     pip3 install yapf
     # Add a script for initializing the flask service.
-    echo 'cd /vagrant && sudo FLASK_APP=service:app flask run --host=0.0.0.0     --port=5000' > init_service.sh
+    echo 'cd /vagrant && sudo FLASK_APP=service:app flask run --host=0.0.0.0 --port=5000' > init_service.sh
     chmod a+x init_service.sh
   SHELL
 


### PR DESCRIPTION
Added a service init script to Vagrantfile. Now we can get the service running just by issuing `./init_service.sh` from the Vagrant environment's home directory.